### PR TITLE
Support more rendering customizations

### DIFF
--- a/pr-review-common.el
+++ b/pr-review-common.el
@@ -59,6 +59,11 @@
   "Face used for author names."
   :group 'pr-review)
 
+(defface pr-review-check-face
+  '((t :inherit pr-review-author-face))
+  "Face used for check names."
+  :group 'pr-review)
+
 (defface pr-review-timestamp-face
   '((t :slant italic))
   "Face used for timestamps."
@@ -80,7 +85,7 @@
   :group 'pr-review)
 
 (defface pr-review-thread-item-title-face
-  '((t :inherit bold))
+  '((t :inherit magit-section-secondary-heading))
   "Face used for title of review thread item."
   :group 'pr-review)
 
@@ -89,19 +94,53 @@
   "Face used for the beginning of thread diff hunk."
   :group 'pr-review)
 
+(defface pr-review-thread-diff-body-face
+  '((t))
+  "Extra face added to the body of thread diff hunk."
+  :group 'pr-review)
+
 (defface pr-review-thread-diff-end-face
   '((t :overline t :extend t :inherit font-lock-comment-face))
   "Face used for the beginning of thread diff hunk."
   :group 'pr-review)
 
+(defface pr-review-thread-comment-face
+  '((t))
+  "Extra face added to review thread comments."
+  :group 'pr-review)
+
 (defface pr-review-in-diff-thread-title-face
   '((t :inherit font-lock-comment-face))
-  "Face used for the title of the in-diff thread title."
+  "Face used for the title of the in-diff review-thread-link title.
+Used if `pr-review-always-use-blocks' is nil (default)."
+  :group 'pr-review)
+
+(defface pr-review-in-diff-thread-begin-face
+  '((t :underline t :extend t :inherit bold-italic))
+  "Face used for start line of review-thread-link block in the diff.
+Used if `pr-review-always-use-blocks' is t."
+  :group 'pr-review)
+
+(defface pr-review-in-diff-thread-body-face
+  '((t))
+  "Extra face added to the comment body of review-thread-link block in the diff.
+Used if `pr-review-always-use-blocks' is t."
+  :group 'pr-review)
+
+(defface pr-review-in-diff-thread-end-face
+  '((t :overline t :extend t :height 0.5 :inherit bold-italic))
+  "Face used for end line of review-thread-link block in the diff.
+Used if `pr-review-always-use-blocks' is t."
   :group 'pr-review)
 
 (defface pr-review-in-diff-pending-begin-face
   '((t :underline t :extend t :inherit bold-italic))
   "Face used for start line of pending-thread in the diff."
+  :group 'pr-review)
+
+(defface pr-review-in-diff-pending-body-face
+  '((t))
+  "Extra face added to the comment body of pending-thread in the diff."
   :group 'pr-review)
 
 (defface pr-review-in-diff-pending-end-face
@@ -162,6 +201,14 @@
   "Regexe that match generated files, which would be collapsed in review."
   :type 'regexp
   :group 'pr-review)
+
+(defvar pr-review-always-use-blocks nil
+  "Always use multi-line blocks, even for elements that are usually on one line.
+With this option, in-diff review thread links becomes blocks.")
+
+(defvar pr-review-always-use-buttons nil
+  "Always use separate buttons, and don't make blocks clickable.
+With this option, buttons are added to diff snippets inside review threads.")
 
 (provide 'pr-review-common)
 ;;; pr-review-common.el ends here

--- a/pr-review-common.el
+++ b/pr-review-common.el
@@ -202,6 +202,13 @@ Used if `pr-review-always-use-blocks' is t."
   :type 'regexp
   :group 'pr-review)
 
+(defvar pr-review-diff-font-lock-syntax 'hunk-also
+  "This value is assigned to `diff-font-lock-syntax' to fontify hunk with diff-mode.
+Set to nil to disable source language syntax highlighting.")
+
+(defvar pr-review-diff-hunk-limit 4
+  "Maximum number of lines shown for diff hunks in review threads.")
+
 (defvar pr-review-always-use-blocks nil
   "Always use multi-line blocks, even for elements that are usually on one line.
 With this option, in-diff review thread links becomes blocks.")

--- a/pr-review-render.el
+++ b/pr-review-render.el
@@ -160,7 +160,7 @@ MARGIN count of spaces are added at the start of every line."
   (with-current-buffer
       (get-buffer-create (format " *pr-review-fontification:%s*" lang-mode))
     (let ((inhibit-modification-hooks nil)
-          (diff-font-lock-syntax 'hunk-also))
+          (diff-font-lock-syntax pr-review-diff-font-lock-syntax))
       (erase-buffer)
       (insert "\n"  ;; insert a newline at first line (and ignore later)
                     ;; to workaround markdown metadata syntax: https://github.com/jrblevin/markdown-mode/issues/328
@@ -435,7 +435,8 @@ It will be inserted at the beginning."
                       (recenter))))
           beg end)
       (setq beg (point))
-      (while (> (length diffhunk-lines) 4)   ;; diffHunk may be very long, only keep last 4 lines
+      ;; diffHunk may be very long, only keep last N lines
+      (while (> (length diffhunk-lines) pr-review-diff-hunk-limit)
         (setq diffhunk-lines (cdr diffhunk-lines)))
       (pr-review--insert-fontified (string-join diffhunk-lines "\n") 'diff-mode
                                    pr-review-section-indent-width

--- a/pr-review.el
+++ b/pr-review.el
@@ -241,7 +241,7 @@ It's used as the default value of `pr-review'."
                                           (when default-pr-path
                                             (apply #'format " (default: %s/%s/%s)"
                                                    default-pr-path))
-                                          ":"))))
+                                          ": "))))
      (if (string-empty-p input-url)
          (or default-url "")
        input-url))


### PR DESCRIPTION
Hi, thanks a lot for this package!

This PR adds a few more granular look and feel customizations. Default look is not affected, but it becomes possible to achieve different appearance.

---

### Appearance

New options:

* `pr-review-always-use-blocks` - If enabled, in-diff links to review threads are rendered as a block instead of a single line.

   This makes them more distinguishable, especially when you're scrolling big diffs. In this mode these blocks will have "Go to thread ↑" button.

* `pr-review-always-use-buttons` - If enabled, diff blocks in review threads are not clickable, instead there is separate button for that.

   I often mis-click on a diff block when trying to select some text in it. In this mode these blocks will have "Go to diff ↓" button.

New faces:

* `pr-review-thread-diff-body-face` - Face for content between `pr-review-thread-diff-begin-face` and `pr-review-thread-diff-end-face`.

* `pr-review-in-diff-pending-body-face` - Face for content between `pr-review-in-diff-pending-begin-face` and `pr-review-in-diff-pending-end-face` 

* `pr-review-in-diff-thread-begin-face`, `pr-review-in-diff-thread-body-face`, `pr-review-in-diff-thread-end-face` - Faces for in-diff review thread link block when `pr-review-always-use-blocks` is enabled.

* `pr-review-thread-comment-face` - Face for review comments text. Previously there were no face.

* `pr-review-check-face` - Separate face for CI checks (by default same as `pr-review-author-face`). Previously `pr-review-author-face` was used for both authors and checks.

Changed faces:

* `pr-review-thread-item-title-face` now inherits `magit-section-secondary-heading` instead of `bold`

Notable changes in code:

* `pr-review--insert-html` and `pr-review--insert-fontified` now have additional argument `extra-face`. When non-nil, this face is added to the inserted text.

   Both functions use `pr-review--decorate-region` helper for that.

* `pr-review--insert-in-diff-review-thread-link` is updated to support two modes, when `pr-review-always-use-blocks` is true or false.

* `pr-review--insert-review-thread-section` is updated to support two modes, when `pr-review-always-use-buttons` is true or false.

---

### Diff hunks

New options:

* `pr-review-diff-font-lock-syntax` - Allows to change diff fontification from `hunk-also` to something else.

   In big diffs, syntax highlighting for diff hunks doesn't play well for me - there are too much colors and it becomes hard to read.

* `pr-review-diff-hunk-limit` - Allows to overwrite default hunk size.

---

### Screenshots

Here are some screenshots from my fork + my theme:

![image](https://github.com/user-attachments/assets/47929f48-b310-4f24-9783-415cf4ae6291)

![image](https://github.com/user-attachments/assets/66f75e3a-afa0-418a-96f5-fd1a6122f7b4)

![image](https://github.com/user-attachments/assets/3b1290cf-fc5a-40f6-8bf6-6c97bfc20ad8)

