### PR TITLE
Support toggling draft state of pull requests

### DIFF
--- a/graphql/convert-pr-to-draft.graphql
+++ b/graphql/convert-pr-to-draft.graphql
@@ -1,0 +1,7 @@
+mutation($input: ConvertPullRequestToDraftInput!) {
+  convertPullRequestToDraft(input: $input) {
+    pullRequest {
+      id
+    }
+  }
+}

--- a/graphql/get-pull-request.graphql
+++ b/graphql/get-pull-request.graphql
@@ -9,6 +9,7 @@ query($repo_owner:String!, $repo_name:String!, $pr_id:Int!) {
       id
       url
       state
+      isDraft
       mergeable
       headRefName
       headRefOid

--- a/graphql/mark-pr-ready-for-review.graphql
+++ b/graphql/mark-pr-ready-for-review.graphql
@@ -1,0 +1,7 @@
+mutation($input: MarkPullRequestReadyForReviewInput!) {
+  markPullRequestReadyForReview(input: $input) {
+    pullRequest {
+      id
+    }
+  }
+}

--- a/pr-review-action.el
+++ b/pr-review-action.el
@@ -271,15 +271,33 @@ Will confirm before sending the request."
     (_
      (error "Cannot close or reopen PR in current state"))))
 
+(defun pr-review-toggle-draft ()
+  "Toggle the draft state of the current PR.
+If the PR is a draft, mark it ready for review.
+Otherwise, convert it back to a draft.
+Will confirm before sending the request."
+  (interactive)
+  (unless (equal (alist-get 'state pr-review--pr-info) "OPEN")
+    (user-error "Cannot toggle draft state on a PR that is not open"))
+  (let ((id (alist-get 'id pr-review--pr-info))
+        (is-draft (eq t (alist-get 'isDraft pr-review--pr-info))))
+    (if is-draft
+        (when (y-or-n-p "Mark this PR as ready for review? ")
+          (pr-review--post-mark-ready-for-review id)
+          (pr-review-refresh))
+      (when (y-or-n-p "Convert this PR back to a draft? ")
+        (pr-review--post-convert-to-draft id)
+        (pr-review-refresh)))))
+
 (cl-defmethod pr-review-general-interactive-action ()
   "Close or re-open or merge, prompt to interactive select the action."
   (let ((action (let ((actions pr-review--merge-methods))
-                       (when-let ((close-or-reopen-action (pr-review--close-or-reopen-action)))
-                         (setq actions
-                               (append actions
-                                       (list (upcase (symbol-name close-or-reopen-action))))))
-                       (completing-read "Select action: "
-                                        actions nil 'require-match))))
+                  (when-let ((close-or-reopen-action (pr-review--close-or-reopen-action)))
+                    (setq actions
+                          (append actions
+                                  (list (upcase (symbol-name close-or-reopen-action))))))
+                  (completing-read "Select action: "
+                                   actions nil 'require-match))))
     (if (member action pr-review--merge-methods)
         (pr-review-merge action)
       (pr-review-close-or-reopen))))

--- a/pr-review-api.el
+++ b/pr-review-api.el
@@ -279,6 +279,18 @@ BODY: review comment body."
    'reopen-pr
    `((input . ((pullRequestId . ,pr-node-id))))))
 
+(defun pr-review--post-mark-ready-for-review (pr-node-id)
+  "Send API request to mark pr PR-NODE-ID as ready for review."
+  (pr-review--execute-graphql
+   'mark-pr-ready-for-review
+   `((input . ((pullRequestId . ,pr-node-id))))))
+
+(defun pr-review--post-convert-to-draft (pr-node-id)
+  "Send API request to convert pr PR-NODE-ID back to a draft."
+  (pr-review--execute-graphql
+   'convert-pr-to-draft
+   `((input . ((pullRequestId . ,pr-node-id))))))
+
 (defun pr-review--search-prs (query)
   "Search pull requests with QUERY."
   (let-alist (pr-review--execute-graphql

--- a/pr-review-render.el
+++ b/pr-review-render.el
@@ -865,6 +865,13 @@ COMMITS is a list of (abbrev-sha full-sha title)"
     (insert-button (upcase (symbol-name close-or-reopen-action))
                    'face 'pr-review-button-face
                    'action (lambda (_) (pr-review-close-or-reopen))))
+  (when (equal (alist-get 'state pr-review--pr-info) "OPEN")
+    (insert ", or ")
+    (insert-button (if (eq t (alist-get 'isDraft pr-review--pr-info))
+                       "MARK READY FOR REVIEW"
+                     "CONVERT TO DRAFT")
+                   'face 'pr-review-button-face
+                   'action (lambda (_) (pr-review-toggle-draft))))
   (insert "\n"))
 
 (defun pr-review--is-timeline-items-groupable (item-a item-b)
@@ -996,7 +1003,10 @@ it can be displayed in a single line."
       (oset section title .title)
       (oset section updatable .viewerCanUpdate)
       (magit-insert-heading
-        (propertize (alist-get 'title pr) 'face 'pr-review-title-face)))
+        (propertize (alist-get 'title pr) 'face 'pr-review-title-face)
+        (when (eq t .isDraft)
+          (concat " " (propertize "[DRAFT]"
+                                  'face 'pr-review-info-state-face)))))
     (insert "\n")
     (pr-review--insert-pr-body pr diff)))
 

--- a/pr-review.el
+++ b/pr-review.el
@@ -58,6 +58,7 @@
     (define-key map (kbd "C-c C-q") #'pr-review-request-reviews)
     (define-key map (kbd "C-c C-l") #'pr-review-set-labels)
     (define-key map (kbd "C-c C-j") #'pr-review-update-reactions)
+    (define-key map (kbd "C-c C-t") #'pr-review-toggle-draft)
     map))
 
 (defvar pr-review--mode-map-setup-for-evil-done nil)


### PR DESCRIPTION
## Summary

Adds support for switching a PR between draft and ready-for-review without leaving Emacs. Useful when iterating on a PR locally — flip it back to draft while you address feedback, then mark it ready again when you're done.

- `pr-review-toggle-draft` (bound to `C-c C-t`): toggles the current PR between draft and ready-for-review. Refuses on non-`OPEN` PRs and confirms before sending.
- `[DRAFT]` badge shown in the title heading using `pr-review-info-state-face` (same face used by `RESOLVED`/`OUTDATED`).
- `MARK READY FOR REVIEW` / `CONVERT TO DRAFT` button rendered next to the close/reopen button on the action row.

## Implementation

- `graphql/get-pull-request.graphql`: fetch `isDraft`.
- `graphql/mark-pr-ready-for-review.graphql`, `graphql/convert-pr-to-draft.graphql`: new mutations using GitHub's `markPullRequestReadyForReview` and `convertPullRequestToDraft`.
- `pr-review--post-mark-ready-for-review`, `pr-review--post-convert-to-draft`: thin API wrappers, matching the existing close/reopen helpers.

## Test plan

- [x] On a draft PR, title shows `[DRAFT]` and the action row offers `MARK READY FOR REVIEW`. Clicking it (or `C-c C-t`) prompts and, on confirmation, marks the PR ready; the buffer refreshes and the badge disappears.
- [x] On an open non-draft PR, the action row offers `CONVERT TO DRAFT`; toggling adds the `[DRAFT]` badge after refresh.
- [x] On a closed PR, `pr-review-toggle-draft` errors with `Cannot toggle draft state on a PR that is not open` and the action button is not rendered.

Filing as draft for review of the chosen approach (button placement, keybinding choice of `C-c C-t`, badge styling) before marking ready.